### PR TITLE
AI用docsをGit管理から外す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Ignore all environment files.
 /.env*
 
+# Ignore local planning documents used during development.
+/docs/
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*


### PR DESCRIPTION
## Summary
- ローカルのAI用作業ドキュメントである `docs/` をGit管理対象から外します。
- ブランチ切り替え時に `docs/plan.md` などが未追跡ファイルとして邪魔にならないようにします。

## Test plan
- [x] `git diff origin/main...HEAD` で `.gitignore` のみ変更されていることを確認
