### PR TITLE
デプロイ時のGoogle OAuth設定を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,10 @@ jobs:
           echo "AWS_ECR_PASSWORD=$AWS_ECR_PASSWORD" > .kamal/secrets
           echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> .kamal/secrets
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .kamal/secrets
+          echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .kamal/secrets
+          echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .kamal/secrets
+          echo "GOOGLE_YOUTUBE_CLIENT_ID=${{ secrets.GOOGLE_YOUTUBE_CLIENT_ID }}" >> .kamal/secrets
+          echo "GOOGLE_YOUTUBE_CLIENT_SECRET=${{ secrets.GOOGLE_YOUTUBE_CLIENT_SECRET }}" >> .kamal/secrets
 
       - name: Deploy with Kamal
         run: bin/kamal deploy

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -18,6 +18,10 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - DATABASE_URL
+    - GOOGLE_CLIENT_ID
+    - GOOGLE_CLIENT_SECRET
+    - GOOGLE_YOUTUBE_CLIENT_ID
+    - GOOGLE_YOUTUBE_CLIENT_SECRET
 
 asset_path: /rails/public/assets
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return if ENV['SECRET_KEY_BASE_DUMMY'] == '1'
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
     ENV.fetch('GOOGLE_CLIENT_ID'),


### PR DESCRIPTION
## Summary

- Docker ビルドの `assets:precompile` 時は `SECRET_KEY_BASE_DUMMY=1` のため OAuth 設定をスキップし、イメージビルド失敗を防ぐ
- 本番コンテナには Google OAuth 4変数を Kamal 経由で渡すよう `config/deploy.yml` と `deploy.yml` を更新

## 背景

`omniauth.rb` を `ENV.fetch`（デフォルトなし）に変更した後、Docker ビルドで `GOOGLE_CLIENT_ID` 未設定により `assets:precompile` が失敗していた。

## Test plan

- [ ] GitHub Repository secrets に `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_YOUTUBE_CLIENT_ID` / `GOOGLE_YOUTUBE_CLIENT_SECRET` を登録済み
- [ ] `SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile` が成功する
- [ ] main マージ後の Deploy workflow でイメージビルドが通る
- [ ] 本番で Google ログインが動作する