### PR TITLE
本番RDS接続にSSLを必須化する

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,15 +17,19 @@ production:
   primary:
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+    sslmode: require
   cache:
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+    sslmode: require
     migrations_paths: db/cache_migrate
   queue:
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+    sslmode: require
     migrations_paths: db/queue_migrate
   cable:
     <<: *default
     url: <%= ENV["DATABASE_URL"] %>
+    sslmode: require
     migrations_paths: db/cable_migrate


### PR DESCRIPTION
## Summary

- 本番環境の PostgreSQL 接続（primary / cache / queue / cable）に `sslmode: require` を追加
- AWS RDS が暗号化なし接続を拒否する場合の `no pg_hba.conf entry ... no encryption` エラーを解消

## 背景

Kamal デプロイ時に `db:prepare` が失敗し、コンテナが healthy にならない。ログに `no encryption` が出ており、EC2 上での接続テストでも `sslmode=require` 付きで当該エラーが消えることを確認済み。

## Test plan

- [ ] main マージ後の Deploy workflow で `db:prepare` が成功する
- [ ] 本番アプリが起動し DB 接続できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 本番環境のデータベース接続設定を更新し、SSL接続の必須化を実装しました。プライマリ、キャッシュ、キュー、ケーブル接続を含むすべての本番データベース接続が、セキュアな通信を必須とするようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->