### PR TITLE
動画一覧ページを実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,10 +1,53 @@
-/*
- * This is a manifest file that'll be compiled into application.css.
- *
- * With Propshaft, assets are served efficiently without preprocessing steps. You can still include
- * application-wide styles in this file, but keep in mind that CSS precedence will follow the standard
- * cascading order, meaning styles declared later in the document or manifest will override earlier ones,
- * depending on specificity.
- *
- * Consider organizing styles into separate files for maintainability.
- */
+.video-card {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.video-thumbnail {
+  width: 240px;
+  height: 135px;
+  object-fit: cover;
+}
+
+.channel-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.channel-icon {
+  border-radius: 50%;
+}
+
+.video-title {
+  margin: 0.25rem 0;
+}
+
+.video-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.video-meta {
+  color: #606060;
+  font-size: 0.875rem;
+}
+
+.empty-icon {
+  font-size: 3rem;
+  text-align: center;
+}
+
+.empty-state {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+section.live,
+section.upcoming,
+section.archives {
+  margin-bottom: 2rem;
+}

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class VideosController < ApplicationController
+  before_action :require_login
+
   def index
-    @videos = Video.all
+    @follows = current_user.follows
+    display = Video.display_videos(current_user)
+    @live_streams = display[:live_streams]
+    @upcoming_streams = display[:upcoming_streams]
+    @archives = display[:archives]
   end
 end

--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -1,2 +1,11 @@
+# frozen_string_literal: true
+
 module VideosHelper
+  def video_time_label(video)
+    "#{time_ago_in_words(video.published_at)}前"
+  end
+
+  def youtube_video_url(video)
+    "https://www.youtube.com/watch?v=#{video.youtube_video_id}"
+  end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -11,4 +11,39 @@ class Video < ApplicationRecord
             :thumbnail_url,
             :title,
             presence: true
+
+  scope :live, -> { where(live_broadcast_status: 'live') }
+  scope :upcoming, -> { where(live_broadcast_status: 'upcoming') }
+  scope :archives, -> { where(live_broadcast_status: 'none') }
+
+  def self.display_videos(user)
+    videos = where(channel: user.followed_channels).includes(:channel)
+    terms_by_channel = user.channel_filter_terms.group_by(&:channel_id)
+
+    {
+      live_streams: live_streams(videos),
+      upcoming_streams: upcoming_streams(videos),
+      archives: filtering_archives(videos, terms_by_channel)
+    }
+  end
+
+  def self.live_streams(videos)
+    videos.live.order(published_at: :desc)
+  end
+
+  def self.upcoming_streams(videos)
+    videos.upcoming.order(Arel.sql('live_start_time ASC NULLS LAST, published_at ASC'))
+  end
+
+  def self.filtering_archives(videos, terms_by_channel)
+    archive_videos = videos.archives.select do |video|
+      terms = terms_by_channel[video.channel_id]
+
+      terms.blank? || terms.any? { |term| video.title.downcase.include?(term.name.downcase) }
+    end
+
+    archive_videos.sort_by(&:published_at).reverse
+  end
+
+  private_class_method :live_streams, :upcoming_streams, :filtering_archives
 end

--- a/app/views/videos/_video_card.html.slim
+++ b/app/views/videos/_video_card.html.slim
@@ -1,0 +1,13 @@
+.video-card
+  = link_to youtube_video_url(video), target: '_blank', rel: 'noopener', class: 'video-thumbnail-link' do
+    = image_tag video.thumbnail_url, alt: video.title, class: 'video-thumbnail'
+
+  .video-info
+    = link_to video.channel.url, target: '_blank', rel: 'noopener', class: 'channel-link' do
+      = image_tag video.channel.icon_url, alt: video.channel.name, class: 'channel-icon', width: 36, height: 36
+      span.channel-name = video.channel.name
+
+    h3.video-title
+      = link_to video.title, youtube_video_url(video), target: '_blank', rel: 'noopener'
+
+    p.video-meta = video_time_label(video)

--- a/app/views/videos/index.html.slim
+++ b/app/views/videos/index.html.slim
@@ -1,4 +1,29 @@
-h1 Videos#index
+h1 動画一覧
 
-- if @videos.empty?
-  = link_to 'チャンネルをフォローする', follows_path
+- if @follows.empty?
+  section.no-follows
+    p チャンネルをフォローしましょう
+    = link_to 'フォロー画面へ', follows_path
+- else
+  - if @live_streams.any?
+    section.live
+      h2 ライブ配信中
+      - @live_streams.each do |video|
+        = render 'video_card', video: video
+
+  - if @upcoming_streams.any?
+    section.upcoming
+      h2 配信予定
+      - @upcoming_streams.each do |video|
+        = render 'video_card', video: video
+
+  - if @archives.any?
+    section.archives
+      h2 アーカイブ
+      - @archives.each do |video|
+        = render 'video_card', video: video
+
+  - if @live_streams.empty? && @upcoming_streams.empty? && @archives.empty?
+    section.empty-state
+      p.empty-icon 📭
+      p 動画がありません

--- a/spec/factories/channel_filter_terms.rb
+++ b/spec/factories/channel_filter_terms.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :channel_filter_term do
-    user { nil }
-    channel { nil }
-    name { 'MyString' }
+    user
+    channel
+    name { 'Ruby' }
   end
 end

--- a/spec/factories/channels.rb
+++ b/spec/factories/channels.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :channel do
     sequence(:youtube_channel_id) { |n| "UC#{n}" }
     name { 'MyString' }
-    url { 'MyString' }
-    icon_url { 'MyString' }
+    url { 'https://www.youtube.com/channel/UCexample' }
+    icon_url { 'https://example.com/icon.jpg' }
     videos_playlist_id { 'MyString' }
     videos_refreshed_at { '2026-06-08 19:56:32' }
   end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,14 +1,32 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :video do
-    channel { nil }
-    youtube_video_id { 'MyString' }
-    title { 'MyString' }
-    description { 'MyText' }
-    thumbnail_url { 'MyString' }
-    live_broadcast_status { 'MyString' }
-    published_at { '2026-06-08 19:57:00' }
-    live_start_time { '2026-06-08 19:57:00' }
-    live_end_time { '2026-06-08 19:57:00' }
-    data_refreshed_at { '2026-06-08 19:57:00' }
+    channel
+    sequence(:youtube_video_id) { |n| "video_#{n}" }
+    title { 'Sample Video' }
+    description { 'Sample description' }
+    thumbnail_url { 'https://example.com/thumbnail.jpg' }
+    live_broadcast_status { 'none' }
+    published_at { Time.zone.parse('2026-06-08 19:57:00') }
+    live_start_time { nil }
+    live_end_time { nil }
+    data_refreshed_at { Time.zone.parse('2026-06-08 19:57:00') }
+
+    trait :live do
+      live_broadcast_status { 'live' }
+      live_start_time { 1.hour.ago }
+    end
+
+    trait :upcoming do
+      live_broadcast_status { 'upcoming' }
+      live_start_time { 1.hour.from_now }
+    end
+
+    trait :archive do
+      live_broadcast_status { 'none' }
+      live_start_time { nil }
+      live_end_time { nil }
+    end
   end
 end

--- a/spec/helpers/videos_helper_spec.rb
+++ b/spec/helpers/videos_helper_spec.rb
@@ -1,15 +1,21 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-# Specs in this file have access to a helper object that includes
-# the VideosHelper. For example:
-#
-# describe VideosHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 RSpec.describe VideosHelper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#video_time_label' do
+    it 'returns elapsed time with 前 suffix' do
+      video = build(:video, published_at: 2.hours.ago)
+
+      expect(helper.video_time_label(video)).to include('前')
+    end
+  end
+
+  describe '#youtube_video_url' do
+    it 'returns YouTube watch URL' do
+      video = build(:video, youtube_video_id: 'abc123')
+
+      expect(helper.youtube_video_url(video)).to eq('https://www.youtube.com/watch?v=abc123')
+    end
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,5 +1,118 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Video do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.display_videos' do
+    let(:user) { create(:user) }
+    let(:followed_channel) { create(:channel, name: 'Followed Channel') }
+    let(:unfollowed_channel) { create(:channel, name: 'Unfollowed Channel') }
+
+    before do
+      create(:follow, user:, channel: followed_channel)
+    end
+
+    it 'returns only videos from followed channels' do
+      followed_video = create(:video, :archive, channel: followed_channel, title: 'Followed Video')
+      create(:video, :archive, channel: unfollowed_channel, title: 'Unfollowed Video')
+
+      result = described_class.display_videos(user)
+
+      expect(result[:archives]).to contain_exactly(followed_video)
+      expect(result[:live_streams]).to be_empty
+      expect(result[:upcoming_streams]).to be_empty
+    end
+
+    context 'when live videos exist' do
+      let!(:older_live) do
+        create(:video, :live, channel: followed_channel, title: 'Older Live', published_at: 2.hours.ago)
+      end
+      let!(:newer_live) do
+        create(:video, :live, channel: followed_channel, title: 'Newer Live', published_at: 1.hour.ago)
+      end
+
+      it 'returns live videos sorted newest first' do
+        expect(described_class.display_videos(user)[:live_streams]).to eq([newer_live, older_live])
+      end
+    end
+
+    context 'when upcoming videos exist' do
+      let!(:later_upcoming) do
+        create(
+          :video, :upcoming,
+          channel: followed_channel,
+          title: 'Later Upcoming',
+          live_start_time: 3.hours.from_now,
+          published_at: 1.day.ago
+        )
+      end
+      let!(:sooner_upcoming) do
+        create(
+          :video, :upcoming,
+          channel: followed_channel,
+          title: 'Sooner Upcoming',
+          live_start_time: 1.hour.from_now,
+          published_at: 1.day.ago
+        )
+      end
+
+      it 'returns upcoming videos sorted by soonest live_start_time first' do
+        expect(described_class.display_videos(user)[:upcoming_streams]).to eq([sooner_upcoming, later_upcoming])
+      end
+    end
+
+    context 'when archive videos exist without filter terms' do
+      let!(:first_archive) do
+        create(:video, :archive, channel: followed_channel, title: 'First Archive', published_at: 2.days.ago)
+      end
+      let!(:second_archive) do
+        create(:video, :archive, channel: followed_channel, title: 'Second Archive', published_at: 1.day.ago)
+      end
+
+      it 'returns all archive videos' do
+        expect(described_class.display_videos(user)[:archives]).to eq([second_archive, first_archive])
+      end
+    end
+
+    it 'filters archive videos by channel filter terms case-insensitively' do
+      create(:channel_filter_term, user:, channel: followed_channel, name: 'Ruby')
+      matched_video = create(
+        :video, :archive,
+        channel: followed_channel,
+        title: 'Ruby on Rails入門',
+        published_at: 1.day.ago
+      )
+      create(:video, :archive, channel: followed_channel, title: 'Python入門', published_at: 2.days.ago)
+
+      expect(described_class.display_videos(user)[:archives]).to contain_exactly(matched_video)
+    end
+
+    context 'when filter terms exist' do
+      before do
+        create(:channel_filter_term, user:, channel: followed_channel, name: 'Ruby')
+        create(:video, :archive, channel: followed_channel, title: 'Python Archive', published_at: 1.day.ago)
+      end
+
+      let!(:live_video) do
+        create(:video, :live, channel: followed_channel, title: 'Python Live', published_at: 1.hour.ago)
+      end
+      let!(:upcoming_video) do
+        create(
+          :video, :upcoming,
+          channel: followed_channel,
+          title: 'Python Upcoming',
+          live_start_time: 2.hours.from_now,
+          published_at: 1.day.ago
+        )
+      end
+
+      it 'does not filter live and upcoming videos' do
+        result = described_class.display_videos(user)
+
+        expect(result[:live_streams]).to contain_exactly(live_video)
+        expect(result[:upcoming_streams]).to contain_exactly(upcoming_video)
+        expect(result[:archives]).to be_empty
+      end
+    end
+  end
 end

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -1,5 +1,44 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Videos' do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  describe 'GET /videos' do
+    context 'when logged out' do
+      it 'redirects to root path' do
+        get videos_path
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when logged in' do
+      before { sign_in(user) }
+
+      it 'returns success' do
+        get videos_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'shows follow prompt when user has no follows' do
+        get videos_path
+
+        expect(response.body).to include('チャンネルをフォローしましょう')
+        expect(response.body).to include(follows_path)
+      end
+
+      it 'shows live section when live videos exist' do
+        channel = create(:channel)
+        create(:follow, user:, channel:)
+        create(:video, :live, channel:, title: 'Live Stream Title')
+
+        get videos_path
+
+        expect(response.body).to include('Live Stream Title')
+      end
+    end
+  end
 end

--- a/spec/support/request_auth_support.rb
+++ b/spec/support/request_auth_support.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RequestAuthSupport
+  def sign_in(user)
+    # request spec では session 直接操作が難しいため current_user をスタブ
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+end
+
+RSpec.configure do |config|
+  config.include RequestAuthSupport, type: :request
+end

--- a/spec/system/videos_spec.rb
+++ b/spec/system/videos_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Videos' do
+  let(:user) { create(:user) }
+  let(:channel) { create(:channel, name: 'Test Channel', url: 'https://www.youtube.com/channel/UCtest') }
+
+  before { sign_in_with_google(user) }
+
+  context 'when user has no follows' do
+    scenario 'shows follow prompt' do
+      visit videos_path
+
+      expect(page).to have_text('チャンネルをフォローしましょう')
+      expect(page).to have_link('フォロー画面へ', href: follows_path)
+    end
+  end
+
+  context 'when live videos exist' do
+    before do
+      create(:follow, user:, channel:)
+      create(:video, :live, channel:, title: 'Live Now')
+    end
+
+    scenario 'shows live section' do
+      visit videos_path
+
+      expect(page).to have_css('section.live')
+      expect(page).to have_text('ライブ配信中')
+      expect(page).to have_text('Live Now')
+    end
+  end
+
+  context 'when upcoming videos exist' do
+    before do
+      create(:follow, user:, channel:)
+      create(:video, :upcoming, channel:, title: 'Upcoming Stream')
+    end
+
+    scenario 'shows upcoming section' do
+      visit videos_path
+
+      expect(page).to have_css('section.upcoming')
+      expect(page).to have_text('配信予定')
+      expect(page).to have_text('Upcoming Stream')
+    end
+  end
+
+  context 'when only archive videos exist' do
+    before do
+      create(:follow, user:, channel:)
+      create(:video, :archive, channel:, title: 'Archived Video')
+    end
+
+    scenario 'shows archives section' do
+      visit videos_path
+
+      expect(page).to have_css('section.archives')
+      expect(page).to have_text('アーカイブ')
+      expect(page).to have_text('Archived Video')
+    end
+  end
+
+  context 'when filter terms exist' do
+    before do
+      create(:follow, user:, channel:)
+      create(:channel_filter_term, user:, channel:, name: 'Ruby')
+      create(:video, :live, channel:, title: 'Python Live')
+      create(:video, :upcoming, channel:, title: 'Python Upcoming', live_start_time: 2.hours.from_now)
+      create(:video, :archive, channel:, title: 'Ruby Tutorial')
+      create(:video, :archive, channel:, title: 'Python Tutorial')
+    end
+
+    scenario 'filters archives but not live or upcoming' do
+      visit videos_path
+
+      expect(page).to have_text('Python Live')
+      expect(page).to have_text('Python Upcoming')
+      expect(page).to have_text('Ruby Tutorial')
+      expect(page).to have_no_text('Python Tutorial')
+    end
+  end
+
+  context 'when no videos exist' do
+    before do
+      create(:follow, user:, channel:)
+    end
+
+    scenario 'shows empty state' do
+      visit videos_path
+
+      expect(page).to have_text('動画がありません')
+    end
+  end
+
+  context 'when channel link is displayed' do
+    before do
+      create(:follow, user:, channel:)
+      create(:video, :archive, channel:, title: 'Channel Link Test')
+    end
+
+    scenario 'links channel icon and name to YouTube channel' do
+      visit videos_path
+
+      expect(page).to have_link('Test Channel', href: 'https://www.youtube.com/channel/UCtest')
+    end
+  end
+end


### PR DESCRIPTION
動画一覧ページを実装
## スコープ外

- YouTube API からの動画取得
- チャンネル更新 Job + Turbo 通知
- ページネーション
- 視聴回数表示 → #107

## Test plan

- [x] `bundle exec rspec` 全件パス（43 examples, 0 failures）
- [ ] ログイン後 `/videos` で3区分表示を目視確認
- [ ] フォロー0件時にフォロー画面への誘導が表示される
- [ ] フィルター語句設定済みチャンネルで archives のみ絞り込まれる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォロー中のチャンネルに基づいたパーソナライズされた動画フィードを表示
  * 動画をライブ配信中、配信予定、アーカイブの3つのセクションに分類
  * 動画カードに チャンネルアイコン、タイトル、メタ情報を表示

* **改善**
  * ビデオページへのアクセスにログインが必須に
  * 動画カードのスタイリングと レイアウトを改善
  * フォローがない場合の空状態表示を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->